### PR TITLE
移除GA统计代码

### DIFF
--- a/lianxi/index.html
+++ b/lianxi/index.html
@@ -82,15 +82,6 @@
             text-decoration: none;
         }
     </style>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-Z9TZXQQWT7"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-
-        gtag('config', 'G-Z9TZXQQWT7');
-    </script>
 </head>
 <body>
     


### PR DESCRIPTION
移除来自其他网站的GA统计代码

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the Google Analytics tracking code from the `lianxi/index.html` file.

### Detailed summary
- Deleted the comment indicating the Google Analytics global site tag.
- Removed the `<script>` tag that asynchronously loads the Google Analytics script.
- Eliminated the `<script>` block that initializes and configures Google Analytics.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->